### PR TITLE
🔀 :: (#54) - Fire Unnecessary Code(TextAlign -> Center)

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,13 +2,23 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="JoinScreenPreview">
-        <State />
+      <entry key="CommunityModifierPre">
+        <State>
+          <targetSelectedWithDropDown>
+            <Target>
+              <type value="QUICK_BOOT_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="VIRTUAL_DEVICE_PATH" />
+                  <value value="$USER_HOME$/.android/avd/Pixel_3a_API_34_extension_level_7_arm64-v8a.avd" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </targetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-06-26T00:43:20.441959Z" />
+        </State>
       </entry>
-      <entry key="LoginScreenPre">
-        <State />
-      </entry>
-      <entry key="MainScreenPriview">
+      <entry key="JDSNoOutLinedTextFieldPreview">
         <State />
       </entry>
       <entry key="app">

--- a/app/src/main/java/com/jusiCool/jusicool_android/JusiCool_Android_NavHost.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/JusiCool_Android_NavHost.kt
@@ -72,6 +72,6 @@ fun JusiCool_Android_NavHost(
             navigateToStockBuying = { TODO() },
             navigateToStockSell = { TODO() },
             navigateToCommunity = { TODO() },
-        )
+        )   
     }
 }

--- a/design-system/src/main/java/com/example/design_system/theme/JDSTypography.kt
+++ b/design-system/src/main/java/com/example/design_system/theme/JDSTypography.kt
@@ -48,7 +48,6 @@ object JDSTypography {
         fontSize = 18.sp,
         lineHeight = 27.sp,
         fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
     )
 
     @Stable
@@ -57,7 +56,6 @@ object JDSTypography {
         fontSize = 18.sp,
         lineHeight = 27.sp,
         fontWeight = FontWeight.Normal,
-        textAlign = TextAlign.Center,
     )
 
     @Stable
@@ -66,7 +64,6 @@ object JDSTypography {
         fontSize = 16.sp,
         lineHeight = 22.sp,
         fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
     )
 
     @Stable
@@ -83,7 +80,6 @@ object JDSTypography {
         fontSize = 14.sp,
         lineHeight = 18.sp,
         fontWeight = FontWeight.Normal,
-        textAlign = TextAlign.Center,
     )
 
     @Stable
@@ -92,7 +88,6 @@ object JDSTypography {
         fontSize = 14.sp,
         lineHeight = 20.sp,
         fontWeight = FontWeight.Normal,
-        textAlign = TextAlign.Center
     )
 
     @Stable
@@ -101,6 +96,5 @@ object JDSTypography {
         fontSize = 16.sp,
         lineHeight = 22.sp,
         fontWeight = FontWeight.Normal,
-        textAlign = TextAlign.Center
     )
 }


### PR DESCRIPTION
## 💡 개요
- typography에서 불필요한 코드를 삭제해야합니다
## 📃 작업내용
- typography에서 textalign = center를 삭제합니다
## 🔀 변경사항
chore JDStypography
## 🙋‍♂️ 질문사항
- q&a
## 🍴 사용방법
- 잘
## 🎸 기타
- guitar