### PR TITLE
🔀 :: (#70) - board에 대한 API를 UseCase까지 작업합니다!

### DIFF
--- a/app/src/main/java/com/jusiCool/jusicool_android/module/NetworkModule.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/module/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.jusiCool.jusicool_android.module
 
 import android.util.Log
+import com.jusiCool.data.remote.api.BoardAPI
 import com.jusiCool.data.utill.AuthInterceptor
 import com.squareup.moshi.Moshi
 import dagger.Module
@@ -60,5 +61,9 @@ object NetworkModule {
         .addConverterFactory(moshiConverterFactory)
         .build()
 
-    // Todo : Add Other API Provide
+    @Provides
+    @Singleton
+    fun BoardAPI(retrofit: Retrofit): BoardAPI {
+        return retrofit.create(BoardAPI::class.java)
+    }
 }

--- a/data/src/main/java/com/jusiCool/data/remote/api/BoardAPI.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/api/BoardAPI.kt
@@ -1,0 +1,34 @@
+package com.jusiCool.data.remote.api
+
+import com.jusiCool.data.remote.dto.board.request.WritingCommunityBoardRequest
+import com.jusiCool.data.remote.dto.board.response.*
+import retrofit2.http.*
+
+interface BoardAPI {
+    @GET("/api/v1/board/list")
+    suspend fun getCommunityList(
+        @Path("community_id") communityId: Long
+    ) : List<GetCommunityBoardListResponse>
+
+    @GET("/api/v1/board")
+    suspend fun getCommunityDetail(
+        @Path("board_id") boardId: Long
+    ) : GetCommunityBoardDetailResponse
+
+    @POST("/api/v1/board")
+    suspend fun postWritingCommunity(
+        @Path("community_id") communityId: Long,
+        @Body body: WritingCommunityBoardRequest
+    )
+
+    @PATCH("/api/v1/board")
+    suspend fun patchBoardCommunity(
+        @Path("board_id") boardId: Long,
+        @Body body: WritingCommunityBoardRequest
+    )
+
+    @DELETE("/api/v1/board")
+    suspend fun deleteBoardCommunity(
+        @Path("board_id") boardId: Long
+    )
+}

--- a/data/src/main/java/com/jusiCool/data/remote/datesource/board/RemoteBoardDataSource.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/datesource/board/RemoteBoardDataSource.kt
@@ -1,0 +1,14 @@
+package com.jusiCool.data.remote.datesource.board
+
+import com.jusiCool.data.remote.dto.board.request.WritingCommunityBoardRequest
+import com.jusiCool.data.remote.dto.board.response.GetCommunityBoardDetailResponse
+import com.jusiCool.data.remote.dto.board.response.GetCommunityBoardListResponse
+import kotlinx.coroutines.flow.Flow
+
+interface RemoteBoardDataSource {
+    suspend fun getCommunityList(communityId: Long) : Flow<List<GetCommunityBoardListResponse>>
+    suspend fun getCommunityDetail(boardId: Long) : Flow<GetCommunityBoardDetailResponse>
+    suspend fun postCommunityBoard(communityId: Long ,body: WritingCommunityBoardRequest) : Flow<Unit>
+    suspend fun patchCommunityBoard(boardId: Long, body: WritingCommunityBoardRequest) : Flow<Unit>
+    suspend fun deleteCommunityBoard(boardId: Long) : Flow<Unit>
+}

--- a/data/src/main/java/com/jusiCool/data/remote/datesource/board/RemoteBoardDataSourceImpl.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/datesource/board/RemoteBoardDataSourceImpl.kt
@@ -1,0 +1,40 @@
+package com.jusiCool.data.remote.datesource.board
+
+import com.jusiCool.data.remote.api.BoardAPI
+import com.jusiCool.data.remote.dto.board.request.WritingCommunityBoardRequest
+import com.jusiCool.data.remote.dto.board.response.GetCommunityBoardDetailResponse
+import com.jusiCool.data.remote.dto.board.response.GetCommunityBoardListResponse
+import com.jusiCool.data.utill.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class RemoteBoardDataSourceImpl @Inject constructor(
+    private val boardService: BoardAPI
+) : RemoteBoardDataSource {
+    override suspend fun getCommunityList(communityId: Long): Flow<List<GetCommunityBoardListResponse>> =
+        performApiRequest { boardService.getCommunityList(communityId = communityId) }
+
+    override suspend fun getCommunityDetail(boardId: Long): Flow<GetCommunityBoardDetailResponse> =
+        performApiRequest { boardService.getCommunityDetail(boardId = boardId) }
+
+    override suspend fun postCommunityBoard(
+        communityId: Long,
+        body: WritingCommunityBoardRequest
+    ): Flow<Unit> =
+        performApiRequest { boardService.postWritingCommunity(
+            communityId = communityId,
+            body = body
+        ) }
+
+    override suspend fun patchCommunityBoard(
+        boardId: Long,
+        body: WritingCommunityBoardRequest
+    ): Flow<Unit> =
+        performApiRequest { boardService.patchBoardCommunity(
+            boardId = boardId,
+            body = body
+        ) }
+
+    override suspend fun deleteCommunityBoard(boardId: Long): Flow<Unit> =
+        performApiRequest { boardService.deleteBoardCommunity(boardId = boardId) }
+}

--- a/data/src/main/java/com/jusiCool/data/remote/dto/board/request/WritingCommunityBoardRequest.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/board/request/WritingCommunityBoardRequest.kt
@@ -1,0 +1,16 @@
+package com.jusiCool.data.remote.dto.board.request
+
+import com.jusiCool.domain.model.board.request.WritingCommunityBoardRequestModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class WritingCommunityBoardRequest(
+    @Json(name = "title") val title: String,
+    @Json(name = "content") val content: String,
+)
+
+fun WritingCommunityBoardRequestModel.toDto() = WritingCommunityBoardRequest(
+    title = title,
+    content = content
+)

--- a/data/src/main/java/com/jusiCool/data/remote/dto/board/response/GetCommunityBoardDetailResponse.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/board/response/GetCommunityBoardDetailResponse.kt
@@ -1,0 +1,16 @@
+package com.jusiCool.data.remote.dto.board.response
+
+import com.jusiCool.domain.model.board.response.GetCommunityBoardDetailResponseModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class GetCommunityBoardDetailResponse(
+    @Json(name = "title") val title: String,
+    @Json(name = "content") val content: String,
+)
+
+fun GetCommunityBoardDetailResponse.toModel() = GetCommunityBoardDetailResponseModel(
+    title = title,
+    content = content
+)

--- a/data/src/main/java/com/jusiCool/data/remote/dto/board/response/GetCommunityBoardListResponse.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/board/response/GetCommunityBoardListResponse.kt
@@ -1,0 +1,24 @@
+package com.jusiCool.data.remote.dto.board.response
+
+import com.jusiCool.domain.model.board.response.GetCommunityBoardListResponseModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class GetCommunityBoardListResponse(
+    @Json(name = "id") val id: Long,
+    @Json(name = "title") val title: String,
+    @Json(name = "content") val content: String,
+    @Json(name = "createdAt") val createdAt: String,
+    @Json(name = "likes") val likes: Int,
+    @Json(name = "commentNum") val commentNum: Int,
+)
+
+fun GetCommunityBoardListResponse.toModel() = GetCommunityBoardListResponseModel(
+    id = id,
+    title = title,
+    content = content,
+    createdAt = createdAt,
+    likes = likes,
+    commentNum = commentNum
+)

--- a/data/src/main/java/com/jusiCool/data/repository/BoardRepositoryImpl.kt
+++ b/data/src/main/java/com/jusiCool/data/repository/BoardRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.jusiCool.data.repository
+
+import com.jusiCool.data.remote.datesource.board.RemoteBoardDataSource
+import com.jusiCool.data.remote.dto.board.request.toDto
+import com.jusiCool.data.remote.dto.board.response.toModel
+import com.jusiCool.domain.model.board.request.WritingCommunityBoardRequestModel
+import com.jusiCool.domain.model.board.response.GetCommunityBoardDetailResponseModel
+import com.jusiCool.domain.model.board.response.GetCommunityBoardListResponseModel
+import com.jusiCool.domain.repository.BoardRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class BoardRepositoryImpl @Inject constructor(
+    private val dataSource: RemoteBoardDataSource
+) : BoardRepository {
+    override suspend fun getCommunityList(communityId: Long): Flow<List<GetCommunityBoardListResponseModel>> {
+        return dataSource.getCommunityList(communityId = communityId).map { list -> list.map { it.toModel() } }
+    }
+
+    override suspend fun getCommunityDetail(boardId: Long): Flow<GetCommunityBoardDetailResponseModel> {
+        return dataSource.getCommunityDetail(boardId = boardId).map { it.toModel() }
+    }
+
+    override suspend fun postCommunityBoard(
+        communityId: Long,
+        body: WritingCommunityBoardRequestModel
+    ): Flow<Unit> {
+        return dataSource.postCommunityBoard(
+            communityId = communityId,
+            body = body.toDto()
+        )
+    }
+
+    override suspend fun patchCommunityBoard(
+        boardId: Long,
+        body: WritingCommunityBoardRequestModel
+    ): Flow<Unit> {
+        return dataSource.patchCommunityBoard(
+            boardId = boardId,
+            body = body.toDto()
+        )
+    }
+
+    override suspend fun deleteCommunityBoard(boardId: Long): Flow<Unit> {
+        return dataSource.deleteCommunityBoard(boardId = boardId)
+    }
+}

--- a/data/src/main/java/com/jusiCool/data/utill/JusiCoolAPIHandler.kt
+++ b/data/src/main/java/com/jusiCool/data/utill/JusiCoolAPIHandler.kt
@@ -1,0 +1,53 @@
+package com.jusiCool.data.utill
+
+import android.util.Log
+import com.jusiCool.domain.util.exception.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+class JusiCoolAPIHandler<T> {
+    private lateinit var httpRequest: suspend () -> T
+    fun httpRequest(httpRequest: suspend () -> T) =
+        this.apply { this.httpRequest = httpRequest }
+
+    suspend fun sendRequest(): T {
+        return try {
+            Log.d("ApiHandler", "Success")
+            withContext(Dispatchers.IO) {
+                httpRequest.invoke()
+            }
+        } catch (e: HttpException) {
+            val message = e.message
+            Log.e("JusiCoolAPIHandler error", message.toString())
+            throw when (e.code()) {
+                400 -> BadRequestException(message = message)
+
+                401 -> UnauthorizedException(message = message)
+
+                403 -> ForBiddenException(message = message)
+
+                404 -> NotFoundException(message = message)
+
+                409 -> ConflictException(message = message)
+
+                500, 501, 502, 503 -> ServerException(message = message)
+
+                else -> OtherHttpException(
+                    message = message,
+                    code = e.code()
+                )
+            }
+        } catch (e: SocketTimeoutException) { // 408 : 요청시간초과
+            throw TimeOutException(message = e.message)
+        } catch (e: UnknownHostException) { // 클라이언트 인터넷 없음 에러
+            throw NoInternetException()
+        } catch (e: NeedLoginException) { // 토큰 만료
+            throw NeedLoginException()
+        } catch (e: Exception) {  // 알려지지 않은 에러
+            throw UnKnownException(message = e.message)
+        }
+    }
+}

--- a/data/src/main/java/com/jusiCool/data/utill/performApiRequest.kt
+++ b/data/src/main/java/com/jusiCool/data/utill/performApiRequest.kt
@@ -1,0 +1,14 @@
+package com.jusiCool.data.utill
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+internal inline fun <reified T> performApiRequest(crossinline apiCall: suspend () -> T): Flow<T> = flow {
+    emit(
+        JusiCoolAPIHandler<T>()
+            .httpRequest { apiCall() }
+            .sendRequest()
+    )
+}.flowOn(Dispatchers.IO)

--- a/domain/src/main/java/com/jusiCool/domain/model/board/request/WritingCommunityBoardRequestModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/board/request/WritingCommunityBoardRequestModel.kt
@@ -1,0 +1,6 @@
+package com.jusiCool.domain.model.board.request
+
+data class WritingCommunityBoardRequestModel(
+    val title: String,
+    val content: String,
+)

--- a/domain/src/main/java/com/jusiCool/domain/model/board/response/GetCommunityBoardDetailResponseModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/board/response/GetCommunityBoardDetailResponseModel.kt
@@ -1,0 +1,6 @@
+package com.jusiCool.domain.model.board.response
+
+data class GetCommunityBoardDetailResponseModel(
+    val title: String,
+    val content: String,
+)

--- a/domain/src/main/java/com/jusiCool/domain/model/board/response/GetCommunityBoardListResponseModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/board/response/GetCommunityBoardListResponseModel.kt
@@ -1,0 +1,10 @@
+package com.jusiCool.domain.model.board.response
+
+data class GetCommunityBoardListResponseModel(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val createdAt: String,
+    val likes: Int,
+    val commentNum: Int,
+)

--- a/domain/src/main/java/com/jusiCool/domain/repository/BoardRepository.kt
+++ b/domain/src/main/java/com/jusiCool/domain/repository/BoardRepository.kt
@@ -1,0 +1,14 @@
+package com.jusiCool.domain.repository
+
+import com.jusiCool.domain.model.board.request.WritingCommunityBoardRequestModel
+import com.jusiCool.domain.model.board.response.GetCommunityBoardDetailResponseModel
+import com.jusiCool.domain.model.board.response.GetCommunityBoardListResponseModel
+import kotlinx.coroutines.flow.Flow
+
+interface BoardRepository {
+    suspend fun getCommunityList(communityId: Long) : Flow<List<GetCommunityBoardListResponseModel>>
+    suspend fun getCommunityDetail(boardId: Long) : Flow<GetCommunityBoardDetailResponseModel>
+    suspend fun postCommunityBoard(communityId: Long ,body: WritingCommunityBoardRequestModel) : Flow<Unit>
+    suspend fun patchCommunityBoard(boardId: Long, body: WritingCommunityBoardRequestModel) : Flow<Unit>
+    suspend fun deleteCommunityBoard(boardId: Long) : Flow<Unit>
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/board/DeleteCommunityBoardUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/board/DeleteCommunityBoardUseCase.kt
@@ -1,0 +1,10 @@
+package com.jusiCool.domain.usecase.board
+
+import com.jusiCool.domain.repository.BoardRepository
+import javax.inject.Inject
+
+class DeleteCommunityBoardUseCase @Inject constructor(
+    private val repository: BoardRepository
+){
+    suspend operator fun invoke(boardId: Long) = runCatching { repository.deleteCommunityBoard(boardId = boardId) }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/board/GetCommunityDetailUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/board/GetCommunityDetailUseCase.kt
@@ -1,0 +1,12 @@
+package com.jusiCool.domain.usecase.board
+
+import com.jusiCool.domain.repository.BoardRepository
+import javax.inject.Inject
+
+class GetCommunityDetailUseCase @Inject constructor(
+    private val repository: BoardRepository
+) {
+    suspend operator fun invoke(boardId: Long) = runCatching {
+        repository.getCommunityDetail(boardId = boardId)
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/board/GetCommunityListUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/board/GetCommunityListUseCase.kt
@@ -1,0 +1,12 @@
+package com.jusiCool.domain.usecase.board
+
+import com.jusiCool.domain.repository.BoardRepository
+import javax.inject.Inject
+
+class GetCommunityListUseCase @Inject constructor(
+    private val repository: BoardRepository
+){
+    suspend operator fun invoke(communityId: Long) = runCatching {
+        repository.getCommunityList(communityId = communityId)
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/board/PatchCommunityBoardUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/board/PatchCommunityBoardUseCase.kt
@@ -1,0 +1,19 @@
+package com.jusiCool.domain.usecase.board
+
+import com.jusiCool.domain.model.board.request.WritingCommunityBoardRequestModel
+import com.jusiCool.domain.repository.BoardRepository
+import javax.inject.Inject
+
+class PatchCommunityBoardUseCase @Inject constructor(
+    private val repository: BoardRepository
+) {
+    suspend operator fun invoke(
+        boardId: Long,
+        body: WritingCommunityBoardRequestModel
+    ) = runCatching {
+        repository.patchCommunityBoard(
+            boardId = boardId,
+            body = body
+        )
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/board/PostWritingCommunityUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/board/PostWritingCommunityUseCase.kt
@@ -1,0 +1,19 @@
+package com.jusiCool.domain.usecase.board
+
+import com.jusiCool.domain.model.board.request.WritingCommunityBoardRequestModel
+import com.jusiCool.domain.repository.BoardRepository
+import javax.inject.Inject
+
+class PostWritingCommunityUseCase @Inject constructor(
+    private val repository: BoardRepository
+) {
+    suspend operator fun invoke(
+        communityId: Long,
+        body: WritingCommunityBoardRequestModel
+    ) = runCatching {
+        repository.postCommunityBoard(
+            communityId = communityId,
+            body = body
+        )
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/util/exception/BadRequestException.kt
+++ b/domain/src/main/java/com/jusiCool/domain/util/exception/BadRequestException.kt
@@ -1,0 +1,42 @@
+package com.jusiCool.domain.util.exception
+
+class BadRequestException( // 400: 올바르지 않은 요청
+    override val message: String?
+): RuntimeException()
+
+class UnauthorizedException( // 401: 비인증 상태
+    override val message: String?
+) : RuntimeException()
+
+class ForBiddenException( // 403: 권한이 없음
+    override val message: String?
+) : RuntimeException()
+
+class NotFoundException( // 404: 요청한 리소스를 찾을 수 없음
+    override val message: String?
+) : RuntimeException()
+
+class NotAcceptableException(
+    override val message: String?
+) : RuntimeException()
+
+class TimeOutException( // 408: 요청시간초과
+    override val message: String?
+) : RuntimeException()
+
+class ConflictException( // 409: 충돌발생
+    override val message: String?
+) : RuntimeException()
+
+class ServerException( // 50X: 서버에러
+    override val message: String?
+) : RuntimeException()
+
+class OtherHttpException( // 정의되지 않은 HTTP 상태 코드나 사용자 정의 상태 코드
+    val code: Int,
+    override val message: String?
+) : RuntimeException()
+
+class UnKnownException( // 알려지지 않은 에러
+    override val message: String?
+) : RuntimeException()

--- a/domain/src/main/java/com/jusiCool/domain/util/exception/NeedLoginException.kt
+++ b/domain/src/main/java/com/jusiCool/domain/util/exception/NeedLoginException.kt
@@ -1,0 +1,8 @@
+package com.jusiCool.domain.util.exception
+
+import java.io.IOException
+
+class NeedLoginException : IOException() {
+    override val message: String
+        get() = "토큰이 만료되었습니다. 다시 로그인 해주세요"
+}

--- a/domain/src/main/java/com/jusiCool/domain/util/exception/NoInternetException.kt
+++ b/domain/src/main/java/com/jusiCool/domain/util/exception/NoInternetException.kt
@@ -1,0 +1,6 @@
+package com.jusiCool.domain.util.exception
+
+class NoInternetException : RuntimeException() {
+    override val message: String
+        get() = "네트워크가 불안정합니다, 데이터나 와이파이 연결 상태를 확인해주세요."
+}


### PR DESCRIPTION
## 💡 개요
- board api에 대해 네트워크 작업을 해야합니다!

## 📃 작업내용
- board에 대한 네트워크 세팅을 UseCase까지 진행했습니다
- 통신에 필요한 예외들을 추가했습니다

## 🔀 변경사항
- chore NetworkModule
- feat BoardAPI
- feat WritingCommunityBoardRequest(DTO, Model, Mapper)
- feat GetCommunityBoardDetailResponse(DTO, Model, Mapper)
- feat GetCommunityBoardListResponse(DTO, Model, Mapper)
- feat RemoteBoardDataSource(Impl)
- feat BoardRepository(Impl)
- feat GetCommunityListUseCase
- feat GetCommunityDetailUseCase
- feat PostWritingCommunityUseCase
- feat PatchCommunityBoardUseCase
- feat DeleteCommunityBoardUseCase
- feat BadRequestException
- feat NeedLoginException
- feat NoInternetException
- feat JusiCoolAPIHandler
- feat performApiRequest
- add .gitkeep File To Domain Exception Package

## 🙋‍♂️ 질문사항
- Nothing
## 🍴 사용방법
- DataSource는 중북되는 로직이 있기에 따로 함수로 빼서 return이 명시적이지 않은 방법으로 사용이 되었지만 Repository는 DataSource와 중복되는 코드가 많아 구분하기 힘들 수 있어 return을 명시적인 방법으로 사용을 했습니다
## 🎸 기타
- Nothing