### PR TITLE
🔀 :: (#79) - 이메일 관련 API를 UseCase까지 Setting을 했습니다

### DIFF
--- a/app/src/main/java/com/jusiCool/jusicool_android/module/NetworkModule.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/module/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.jusiCool.jusicool_android.module
 import android.util.Log
 import com.jusiCool.data.remote.api.BoardAPI
 import com.jusiCool.data.remote.api.CommentAPI
+import com.jusiCool.data.remote.api.EmailAPI
 import com.jusiCool.data.remote.api.ReservationAPI
 import com.jusiCool.data.utill.AuthInterceptor
 import com.squareup.moshi.Moshi
@@ -78,5 +79,11 @@ object NetworkModule {
     @Singleton
     fun CommentAPI(retrofit: Retrofit): CommentAPI {
         return retrofit.create(CommentAPI::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun EmailAPI(retrofit: Retrofit): EmailAPI {
+        return retrofit.create(EmailAPI::class.java)
     }
 }

--- a/data/src/main/java/com/jusiCool/data/remote/api/EmailAPI.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/api/EmailAPI.kt
@@ -1,0 +1,19 @@
+package com.jusiCool.data.remote.api
+
+import com.jusiCool.data.remote.dto.email.request.GetEmailVerifyRequest
+import com.jusiCool.data.remote.dto.email.request.PostEmailRequest
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface EmailAPI {
+    @POST("/api/v1/email")
+    suspend fun postEmail(
+        @Body body: PostEmailRequest
+    )
+
+    @GET("/api/v1/email")
+    suspend fun getEmailVerify(
+        @Body body: GetEmailVerifyRequest
+    )
+}

--- a/data/src/main/java/com/jusiCool/data/remote/datesource/email/RemoteEmailDataSource.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/datesource/email/RemoteEmailDataSource.kt
@@ -1,0 +1,10 @@
+package com.jusiCool.data.remote.datesource.email
+
+import com.jusiCool.data.remote.dto.email.request.GetEmailVerifyRequest
+import com.jusiCool.data.remote.dto.email.request.PostEmailRequest
+import kotlinx.coroutines.flow.Flow
+
+interface RemoteEmailDataSource {
+    suspend fun postEmail(body: PostEmailRequest) : Flow<Unit>
+    suspend fun getEmailVerify(body: GetEmailVerifyRequest) : Flow<Unit>
+}

--- a/data/src/main/java/com/jusiCool/data/remote/datesource/email/RemoteEmailDataSourceImpl.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/datesource/email/RemoteEmailDataSourceImpl.kt
@@ -1,0 +1,18 @@
+package com.jusiCool.data.remote.datesource.email
+
+import com.jusiCool.data.remote.api.EmailAPI
+import com.jusiCool.data.remote.dto.email.request.GetEmailVerifyRequest
+import com.jusiCool.data.remote.dto.email.request.PostEmailRequest
+import com.jusiCool.data.utill.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class RemoteEmailDataSourceImpl @Inject constructor(
+    private val serviceEmail: EmailAPI
+) : RemoteEmailDataSource {
+    override suspend fun postEmail(body: PostEmailRequest): Flow<Unit> =
+        performApiRequest { serviceEmail.postEmail(body = body) }
+
+    override suspend fun getEmailVerify(body: GetEmailVerifyRequest): Flow<Unit> =
+        performApiRequest { serviceEmail.getEmailVerify(body = body) }
+}

--- a/data/src/main/java/com/jusiCool/data/remote/dto/email/request/GetEmailVerifyRequest.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/email/request/GetEmailVerifyRequest.kt
@@ -1,0 +1,16 @@
+package com.jusiCool.data.remote.dto.email.request
+
+import com.jusiCool.domain.model.email.request.GetEmailVerifyRequestModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class GetEmailVerifyRequest(
+    @Json(name = "email") val email: String,
+    @Json(name = "authCode") val authCode: String,
+)
+
+fun GetEmailVerifyRequestModel.toDto() = GetEmailVerifyRequest(
+    email = email,
+    authCode = authCode
+)

--- a/data/src/main/java/com/jusiCool/data/remote/dto/email/request/PostEmailRequest.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/email/request/PostEmailRequest.kt
@@ -1,0 +1,12 @@
+package com.jusiCool.data.remote.dto.email.request
+
+import com.jusiCool.domain.model.email.request.PostEmailRequestModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostEmailRequest(
+    @Json(name = "email") val email: String,
+)
+
+fun PostEmailRequestModel.toDto() = PostEmailRequest(email = email)

--- a/data/src/main/java/com/jusiCool/data/repository/EmailRepositoryImpl.kt
+++ b/data/src/main/java/com/jusiCool/data/repository/EmailRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.jusiCool.data.repository
+
+import com.jusiCool.data.remote.datesource.email.RemoteEmailDataSource
+import com.jusiCool.data.remote.dto.email.request.toDto
+import com.jusiCool.domain.model.email.request.GetEmailVerifyRequestModel
+import com.jusiCool.domain.model.email.request.PostEmailRequestModel
+import com.jusiCool.domain.repository.EmailRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class EmailRepositoryImpl @Inject constructor(
+    private val dataSource: RemoteEmailDataSource
+) : EmailRepository {
+    override suspend fun postEmail(body: PostEmailRequestModel): Flow<Unit> {
+        return dataSource.postEmail(body = body.toDto())
+    }
+
+    override suspend fun getEmailVerify(body: GetEmailVerifyRequestModel): Flow<Unit> {
+        return dataSource.getEmailVerify(body = body.toDto())
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/model/email/request/GetEmailVerifyRequestModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/email/request/GetEmailVerifyRequestModel.kt
@@ -1,0 +1,6 @@
+package com.jusiCool.domain.model.email.request
+
+data class GetEmailVerifyRequestModel(
+    val email: String,
+    val authCode: String,
+)

--- a/domain/src/main/java/com/jusiCool/domain/model/email/request/PostEmailRequestModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/email/request/PostEmailRequestModel.kt
@@ -1,0 +1,5 @@
+package com.jusiCool.domain.model.email.request
+
+data class PostEmailRequestModel(
+    val email: String,
+)

--- a/domain/src/main/java/com/jusiCool/domain/repository/EmailRepository.kt
+++ b/domain/src/main/java/com/jusiCool/domain/repository/EmailRepository.kt
@@ -1,0 +1,10 @@
+package com.jusiCool.domain.repository
+
+import com.jusiCool.domain.model.email.request.GetEmailVerifyRequestModel
+import com.jusiCool.domain.model.email.request.PostEmailRequestModel
+import kotlinx.coroutines.flow.Flow
+
+interface EmailRepository {
+    suspend fun postEmail(body: PostEmailRequestModel) : Flow<Unit>
+    suspend fun getEmailVerify(body: GetEmailVerifyRequestModel) : Flow<Unit>
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/email/GetEmailVerifyUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/email/GetEmailVerifyUseCase.kt
@@ -1,0 +1,13 @@
+package com.jusiCool.domain.usecase.email
+
+import com.jusiCool.domain.model.email.request.GetEmailVerifyRequestModel
+import com.jusiCool.domain.repository.EmailRepository
+import javax.inject.Inject
+
+class GetEmailVerifyUseCase @Inject constructor(
+    private val repository: EmailRepository
+) {
+    suspend operator fun invoke(body: GetEmailVerifyRequestModel) = runCatching {
+        repository.getEmailVerify(body = body)
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/email/PostEmailUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/email/PostEmailUseCase.kt
@@ -1,0 +1,13 @@
+package com.jusiCool.domain.usecase.email
+
+import com.jusiCool.domain.model.email.request.PostEmailRequestModel
+import com.jusiCool.domain.repository.EmailRepository
+import javax.inject.Inject
+
+class PostEmailUseCase @Inject constructor(
+    private val repository: EmailRepository
+) {
+    suspend operator fun invoke(body: PostEmailRequestModel) = runCatching {
+        repository.postEmail(body = body)
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 이메일 관련 API를 세팅해야합니다
## 📃 작업내용
- 이메일 관련 API를 세팅했습니다
## 🔀 변경사항
- feat PostEmailRequest
- feat GetEmailVerifyRequest
- feat PostEmailRequestModel
- feat GetEmailVerifyRequestModel
- feat RemoteEmailDataSource(Impl)
- feat EmailRepository(Impl)
- feat PostEmailUseCase
- feat GetEmailVerifyUseCase
- chore NetworkModule To EmailAPI
## 🙋‍♂️ 질문사항
- Nothing
## 🍴 사용방법
- Nothing
## 🎸 기타
- Nothing