### PR TITLE
🔀 :: (#83) - Auth 통신을 하기위한 세팅을 했습니다

### DIFF
--- a/app/src/main/java/com/jusiCool/jusicool_android/module/DataStoreModule.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/module/DataStoreModule.kt
@@ -1,0 +1,30 @@
+package com.jusiCool.jusicool_android.module
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.dataStoreFile
+import com.jusiCool.data.AuthToken
+import com.jusiCool.data.local.serializer.AuthTokenSerializer
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    @Provides
+    @Singleton
+    fun provideAuthTokenDataStore(
+        @ApplicationContext context: Context,
+        authTokenSerializer: AuthTokenSerializer
+    ) : DataStore<AuthToken> =
+        DataStoreFactory.create(
+            serializer = authTokenSerializer
+        ) {
+            context.dataStoreFile("authToken.pd")
+        }
+}

--- a/app/src/main/java/com/jusiCool/jusicool_android/module/LocalDataSourceModule.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/module/LocalDataSourceModule.kt
@@ -1,0 +1,17 @@
+package com.jusiCool.jusicool_android.module
+
+import com.jusiCool.data.local.datasource.AuthTokenDataSource
+import com.jusiCool.data.local.datasource.AuthTokenDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocalDataSourceModule {
+    @Binds
+    abstract fun bindAuthTokenDataSource(
+        authTokenDataSourceImpl: AuthTokenDataSourceImpl
+    ) : AuthTokenDataSource
+}

--- a/app/src/main/java/com/jusiCool/jusicool_android/module/NetworkModule.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/module/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.jusiCool.jusicool_android.module
 
 import android.util.Log
+import com.jusiCool.data.remote.api.AuthAPI
 import com.jusiCool.data.remote.api.BoardAPI
 import com.jusiCool.data.remote.api.CommentAPI
 import com.jusiCool.data.remote.api.EmailAPI
@@ -65,6 +66,18 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    fun AuthAPI(retrofit: Retrofit): AuthAPI {
+        return retrofit.create(AuthAPI::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun EmailAPI(retrofit: Retrofit): EmailAPI {
+        return retrofit.create(EmailAPI::class.java)
+    }
+
+    @Provides
+    @Singleton
     fun BoardAPI(retrofit: Retrofit): BoardAPI {
         return retrofit.create(BoardAPI::class.java)
     }
@@ -79,11 +92,5 @@ object NetworkModule {
     @Singleton
     fun CommentAPI(retrofit: Retrofit): CommentAPI {
         return retrofit.create(CommentAPI::class.java)
-    }
-
-    @Provides
-    @Singleton
-    fun EmailAPI(retrofit: Retrofit): EmailAPI {
-        return retrofit.create(EmailAPI::class.java)
     }
 }

--- a/app/src/main/java/com/jusiCool/jusicool_android/module/RemoteDataSourceModule.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/module/RemoteDataSourceModule.kt
@@ -1,5 +1,7 @@
 package com.jusiCool.jusicool_android.module
 
+import com.jusiCool.data.remote.datesource.auth.RemoteAuthDataSource
+import com.jusiCool.data.remote.datesource.auth.RemoteAuthDataSourceImpl
 import com.jusiCool.data.remote.datesource.board.RemoteBoardDataSource
 import com.jusiCool.data.remote.datesource.board.RemoteBoardDataSourceImpl
 import com.jusiCool.data.remote.datesource.comment.RemoteCommentDataSource
@@ -17,6 +19,11 @@ import dagger.hilt.components.SingletonComponent
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RemoteDataSourceModule {
+    @Binds
+    abstract fun provideRemoteAuthDataSource(
+        remoteAuthDataSourceImpl: RemoteAuthDataSourceImpl
+    ) : RemoteAuthDataSource
+
     @Binds
     abstract fun provideRemoteBoardDataSource(
         remoteBoardDataSourceImpl: RemoteBoardDataSourceImpl

--- a/app/src/main/java/com/jusiCool/jusicool_android/module/RepositoryModule.kt
+++ b/app/src/main/java/com/jusiCool/jusicool_android/module/RepositoryModule.kt
@@ -1,16 +1,16 @@
 package com.jusiCool.jusicool_android.module
 
-import com.jusiCool.data.remote.datesource.reservation.RemoteReservationDataSourceImpl
+import com.jusiCool.data.repository.AuthRepositoryImpl
 import com.jusiCool.data.repository.BoardRepositoryImpl
 import com.jusiCool.data.repository.CommentRepositoryImpl
 import com.jusiCool.data.repository.EmailRepositoryImpl
 import com.jusiCool.data.repository.ReservationRepositoryImpl
+import com.jusiCool.domain.repository.AuthRepository
 import com.jusiCool.domain.repository.BoardRepository
 import com.jusiCool.domain.repository.CommentRepository
 import com.jusiCool.domain.repository.EmailRepository
 import com.jusiCool.domain.repository.ReservationRepository
 import dagger.Binds
-import dagger.BindsInstance
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
@@ -18,6 +18,11 @@ import dagger.hilt.components.SingletonComponent
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
+    @Binds
+    abstract fun provideAuthRepository(
+        authRepositoryImpl: AuthRepositoryImpl
+    ) : AuthRepository
+
     @Binds
     abstract fun provideBoardRepository(
         boardRepositoryImpl: BoardRepositoryImpl

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,11 @@ plugins {
     id(Dependency.Hilt.HILT_PLUGIN) version Versions.HILT apply false
     id(Dependency.Google.GOOGLE_SERVICES_PLUGIN) version Versions.GOOGLE_SERVICE_PLUGIN apply false
     id(Dependency.Gradle.KSP) version Versions.KSP apply false
+    id("com.google.protobuf") version "0.9.4" apply false
+}
+
+buildscript {
+    dependencies {
+        classpath ("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
+    }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id(Dependency.Gradle.LIBRARY)
     id(Dependency.Gradle.KOTLIN)
     id(Dependency.Gradle.KSP)
+    id("com.google.protobuf")
 }
 
 android {
@@ -40,6 +41,24 @@ android {
     }
 }
 
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.21.12"
+    }
+    generateProtoTasks {
+        all().forEach { task ->
+            task.builtins {
+                register("java") {
+                    option("lite")
+                }
+                register("kotlin") {
+                    option("lite")
+                }
+            }
+        }
+    }
+}
+
 dependencies {
     implementation(project(":domain"))
 
@@ -62,5 +81,7 @@ dependencies {
 
     implementation ("com.squareup.retrofit2:converter-moshi:2.9.0")
     implementation ("com.squareup.moshi:moshi-kotlin:1.12.0")
-    //ksp("com.squareup.retrofit2:moshi-kotlin-codegen:1.12.0")
+
+    implementation ("androidx.datastore:datastore-core:1.0.0")
+    implementation ("com.google.protobuf:protobuf-kotlin-lite:3.21.12")
 }

--- a/data/src/main/java/com/jusiCool/data/local/datasource/AuthTokenDataSource.kt
+++ b/data/src/main/java/com/jusiCool/data/local/datasource/AuthTokenDataSource.kt
@@ -1,0 +1,23 @@
+package com.jusiCool.data.local.datasource
+
+import kotlinx.coroutines.flow.Flow
+
+interface AuthTokenDataSource {
+    fun getAccessToken(): Flow<String>
+    suspend fun setAccessToken(accessToken: String)
+    suspend fun removeAccessToken()
+
+    fun getAccessTokenExp(): Flow<String>
+    suspend fun setAccessTokenExp(accessTokenExp: String)
+    suspend fun removeAccessTokenExp()
+
+    fun getRefreshToken(): Flow<String>
+    suspend fun setRefreshToken(refreshToken: String)
+    suspend fun removeRefreshToken()
+
+    fun getRefreshTokenExp(): Flow<String>
+    suspend fun setRefreshTokenExp(refreshTokenExp: String)
+    suspend fun removeRefreshTokenExp()
+
+    // Authority?
+}

--- a/data/src/main/java/com/jusiCool/data/local/datasource/AuthTokenDataSourceImpl.kt
+++ b/data/src/main/java/com/jusiCool/data/local/datasource/AuthTokenDataSourceImpl.kt
@@ -1,0 +1,91 @@
+package com.jusiCool.data.local.datasource
+
+import androidx.datastore.core.DataStore
+import com.jusiCool.data.AuthToken
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class AuthTokenDataSourceImpl @Inject constructor(
+    private val authToken: DataStore<AuthToken>
+) : AuthTokenDataSource {
+    override fun getAccessToken(): Flow<String> = authToken.data.map {
+        it.accessToken ?: ""
+    }
+
+    override suspend fun setAccessToken(accessToken: String) {
+        authToken.updateData {
+            it.toBuilder()
+                .setAccessToken(accessToken)
+                .build()
+        }
+    }
+
+    override suspend fun removeAccessToken() {
+        authToken.updateData {
+            it.toBuilder()
+                .clearAccessToken()
+                .build()
+        }
+    }
+
+    override fun getAccessTokenExp(): Flow<String> = authToken.data.map {
+        it.accessExp ?: ""
+    }
+
+    override suspend fun setAccessTokenExp(accessTokenExp: String) {
+        authToken.updateData {
+            it.toBuilder()
+                .setAccessExp(accessTokenExp)
+                .build()
+        }
+    }
+
+    override suspend fun removeAccessTokenExp() {
+        authToken.updateData {
+            it.toBuilder()
+                .clearAccessExp()
+                .build()
+        }
+    }
+
+    override fun getRefreshToken(): Flow<String> = authToken.data.map {
+        it.refreshToken ?: ""
+    }
+
+    override suspend fun setRefreshToken(refreshToken: String) {
+        authToken.updateData {
+            it.toBuilder()
+                .setRefreshToken(refreshToken)
+                .build()
+        }
+    }
+
+    override suspend fun removeRefreshToken() {
+        authToken.updateData {
+            it.toBuilder()
+                .clearRefreshToken()
+                .build()
+        }
+    }
+
+    override fun getRefreshTokenExp(): Flow<String> = authToken.data.map {
+        it.refreshExp ?: ""
+    }
+
+    override suspend fun setRefreshTokenExp(refreshTokenExp: String) {
+        authToken.updateData {
+            it.toBuilder()
+                .setRefreshExp(refreshTokenExp)
+                .build()
+        }
+    }
+
+    override suspend fun removeRefreshTokenExp() {
+        authToken.updateData {
+            it.toBuilder()
+                .clearRefreshExp()
+                .build()
+        }
+    }
+}

--- a/data/src/main/java/com/jusiCool/data/local/serializer/AuthTokenSerializer.kt
+++ b/data/src/main/java/com/jusiCool/data/local/serializer/AuthTokenSerializer.kt
@@ -1,0 +1,24 @@
+package com.jusiCool.data.local.serializer
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import com.jusiCool.data.AuthToken
+import java.io.InputStream
+import java.io.OutputStream
+import javax.inject.Inject
+
+class AuthTokenSerializer @Inject constructor() : Serializer<AuthToken> {
+    override val defaultValue: AuthToken = AuthToken.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): AuthToken =
+        try {
+            AuthToken.parseFrom(input)
+        } catch (e: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto", e)
+        }
+
+    override suspend fun writeTo(t: AuthToken, output: OutputStream) {
+        t.writeTo(output)
+    }
+}

--- a/data/src/main/java/com/jusiCool/data/remote/api/AuthAPI.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/api/AuthAPI.kt
@@ -1,0 +1,27 @@
+package com.jusiCool.data.remote.api
+
+import com.jusiCool.data.remote.dto.auth.request.PostAuthSignInRequest
+import com.jusiCool.data.remote.dto.auth.request.PostAuthSignUpRequest
+import com.jusiCool.data.remote.dto.auth.response.AuthTokenResponse
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+
+interface AuthAPI {
+    @POST("/api/v1/auth/singup")
+    suspend fun postAuthSignUp(
+        @Body body: PostAuthSignUpRequest
+    )
+
+    @POST("/api/v1/auth/signin")
+    suspend fun postAuthSignIn(
+        @Body body: PostAuthSignInRequest
+    ) : AuthTokenResponse
+
+    @PATCH("/api/v1/auth")
+    suspend fun patchAuthTokenRefresh() : AuthTokenResponse
+
+    @DELETE("/api/v1/auth")
+    suspend fun deleteAuth()
+}

--- a/data/src/main/java/com/jusiCool/data/remote/datesource/auth/RemoteAuthDataSource.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/datesource/auth/RemoteAuthDataSource.kt
@@ -1,0 +1,13 @@
+package com.jusiCool.data.remote.datesource.auth
+
+import com.jusiCool.data.remote.dto.auth.request.PostAuthSignInRequest
+import com.jusiCool.data.remote.dto.auth.request.PostAuthSignUpRequest
+import com.jusiCool.data.remote.dto.auth.response.AuthTokenResponse
+import kotlinx.coroutines.flow.Flow
+
+interface RemoteAuthDataSource {
+    suspend fun authSignUp(body: PostAuthSignUpRequest) : Flow<Unit>
+    suspend fun authSignIn(body: PostAuthSignInRequest) : Flow<AuthTokenResponse>
+    suspend fun patchAuthTokenRefresh() : Flow<AuthTokenResponse>
+    suspend fun deleteAuth() : Flow<Unit>
+}

--- a/data/src/main/java/com/jusiCool/data/remote/datesource/auth/RemoteAuthDataSourceImpl.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/datesource/auth/RemoteAuthDataSourceImpl.kt
@@ -1,0 +1,25 @@
+package com.jusiCool.data.remote.datesource.auth
+
+import com.jusiCool.data.remote.api.AuthAPI
+import com.jusiCool.data.remote.dto.auth.request.PostAuthSignInRequest
+import com.jusiCool.data.remote.dto.auth.request.PostAuthSignUpRequest
+import com.jusiCool.data.remote.dto.auth.response.AuthTokenResponse
+import com.jusiCool.data.utill.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class RemoteAuthDataSourceImpl @Inject constructor(
+    private val serviceAuth: AuthAPI
+) : RemoteAuthDataSource {
+    override suspend fun authSignUp(body: PostAuthSignUpRequest): Flow<Unit> =
+        performApiRequest { serviceAuth.postAuthSignUp(body = body) }
+
+    override suspend fun authSignIn(body: PostAuthSignInRequest): Flow<AuthTokenResponse> =
+        performApiRequest { serviceAuth.postAuthSignIn(body = body) }
+
+    override suspend fun patchAuthTokenRefresh(): Flow<AuthTokenResponse> =
+        performApiRequest { serviceAuth.patchAuthTokenRefresh() }
+
+    override suspend fun deleteAuth(): Flow<Unit> =
+        performApiRequest { serviceAuth.deleteAuth() }
+}

--- a/data/src/main/java/com/jusiCool/data/remote/dto/auth/request/PostAuthSignInRequest.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/auth/request/PostAuthSignInRequest.kt
@@ -1,0 +1,16 @@
+package com.jusiCool.data.remote.dto.auth.request
+
+import com.jusiCool.domain.model.auth.request.PostAuthSignInRequestModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostAuthSignInRequest(
+    @Json(name = "email") val email: String,
+    @Json(name = "password") val password: String,
+)
+
+fun PostAuthSignInRequestModel.toDto() = PostAuthSignInRequest(
+    email = email,
+    password = password
+)

--- a/data/src/main/java/com/jusiCool/data/remote/dto/auth/request/PostAuthSignUpRequest.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/auth/request/PostAuthSignUpRequest.kt
@@ -1,0 +1,18 @@
+package com.jusiCool.data.remote.dto.auth.request
+
+import com.jusiCool.domain.model.auth.request.PostAuthSignUpRequestModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostAuthSignUpRequest(
+    @Json(name = "email") val email: String,
+    @Json(name = "name") val name: String,
+    @Json(name = "password") val password: String,
+)
+
+fun PostAuthSignUpRequestModel.toDto() = PostAuthSignUpRequest(
+    email = email,
+    name = name,
+    password = password
+)

--- a/data/src/main/java/com/jusiCool/data/remote/dto/auth/response/AuthTokenResponse.kt
+++ b/data/src/main/java/com/jusiCool/data/remote/dto/auth/response/AuthTokenResponse.kt
@@ -1,0 +1,20 @@
+package com.jusiCool.data.remote.dto.auth.response
+
+import com.jusiCool.domain.model.auth.response.AuthTokenResponseModel
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class AuthTokenResponse(
+    @Json(name = "accessToken") val accessToken: String,
+    @Json(name = "refreshToken") val refreshToken: String,
+    @Json(name = "accessTokenExpiresIn") val accessTokenExpiresIn: String,
+    @Json(name = "refreshTokenExpiresIn") val refreshTokenExpiresIn: String,
+)
+
+fun AuthTokenResponse.toModel() = AuthTokenResponseModel(
+    accessToken = accessToken,
+    refreshToken = refreshToken,
+    accessTokenExpiresIn = accessTokenExpiresIn,
+    refreshTokenExpiresIn = refreshTokenExpiresIn
+)

--- a/data/src/main/java/com/jusiCool/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/jusiCool/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.jusiCool.data.repository
+
+import com.jusiCool.data.remote.datesource.auth.RemoteAuthDataSource
+import com.jusiCool.data.remote.dto.auth.request.toDto
+import com.jusiCool.data.remote.dto.auth.response.toModel
+import com.jusiCool.domain.model.auth.request.PostAuthSignInRequestModel
+import com.jusiCool.domain.model.auth.request.PostAuthSignUpRequestModel
+import com.jusiCool.domain.model.auth.response.AuthTokenResponseModel
+import com.jusiCool.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val dataSource: RemoteAuthDataSource
+) : AuthRepository {
+    override suspend fun authSignUp(body: PostAuthSignUpRequestModel): Flow<Unit> {
+        return dataSource.authSignUp(body = body.toDto())
+    }
+
+    override suspend fun authSignIn(body: PostAuthSignInRequestModel): Flow<AuthTokenResponseModel> {
+        return dataSource.authSignIn(body = body.toDto()).map { it.toModel() }
+    }
+
+    override suspend fun patchAuthTokenRefresh(): Flow<AuthTokenResponseModel> {
+        return dataSource.patchAuthTokenRefresh().map { it.toModel() }
+    }
+
+    override suspend fun deleteAuth(): Flow<Unit> {
+        return dataSource.deleteAuth()
+    }
+}

--- a/data/src/main/java/com/jusiCool/data/utill/AuthInterceptor.kt
+++ b/data/src/main/java/com/jusiCool/data/utill/AuthInterceptor.kt
@@ -1,13 +1,72 @@
 package com.jusiCool.data.utill
 
+import android.util.Log
+import com.jusiCool.data.local.datasource.AuthTokenDataSource
+import com.jusiCool.data.remote.dto.auth.response.AuthTokenResponse
+import com.jusiCool.domain.util.exception.NeedLoginException
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
+import okhttp3.OkHttp
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    // Todo : Add LocalDatasource
+    private val localDataSource: AuthTokenDataSource
 ): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        TODO("Not yet implemented")
+        val request = chain.request()
+        val builder = request.newBuilder()
+        val currentTime = System.currentTimeMillis().toJusiCoolDate()
+        val ignorePath = listOf("/auth", "/email")
+        val path = request.url.encodedPath
+        val method = request.method
+
+        if (ignorePath.contains(path) && method != "PATCH") {
+            return chain.proceed(request)
+        }
+
+        runBlocking {
+            val refreshTime = localDataSource.getRefreshTokenExp().first()
+            val accessTime = localDataSource.getAccessTokenExp().first()
+            val accessToken = localDataSource.getAccessToken().first()
+            val refreshToken = localDataSource.getRefreshToken().first()
+
+            if (refreshTime == "") return@runBlocking
+
+            if (currentTime.after(refreshTime.toDate())) throw NeedLoginException()
+
+            if (currentTime.after(accessTime.toDate())) {
+                val client = OkHttpClient()
+                val refreshRequest = Request.Builder()
+                    .url("adfasdfasdfasdfa" + "/api/v1/auth") // BaseUrl 추후 작성
+                    .patch(chain.request().body ?: RequestBody.Companion.create(null, byteArrayOf()))
+                    .addHeader("refreshToken", "Bearer $refreshToken")
+                    .build()
+
+                val moshi = Moshi.Builder().build()
+                val adapter: JsonAdapter<AuthTokenResponse> = moshi.adapter(AuthTokenResponse::class.java)
+                val response = client.newCall(refreshRequest).execute()
+                if (response.isSuccessful) {
+                    val token = adapter.fromJson(response.body!!.string()) ?: throw NeedLoginException()
+                    localDataSource.setAccessToken(token.accessToken)
+                    localDataSource.setAccessTokenExp(token.accessTokenExpiresIn)
+                    localDataSource.setRefreshToken(token.refreshToken)
+                    localDataSource.setRefreshTokenExp(token.refreshTokenExpiresIn)
+                } else throw NeedLoginException()
+            } else {
+                builder.addHeader("Authorization", "Bearer $accessToken")
+            }
+            if (method == "PATCH") {
+                builder.addHeader(name = "refreshToken", value = "Bearer $refreshToken")
+            }
+            builder.header(name = "Authorization", value = "Bearer $accessToken")
+        }
+        return chain.proceed(builder.build())
     }
 }

--- a/data/src/main/java/com/jusiCool/data/utill/DateTimeFormatter.kt
+++ b/data/src/main/java/com/jusiCool/data/utill/DateTimeFormatter.kt
@@ -1,0 +1,21 @@
+package com.jusiCool.data.utill
+
+import android.annotation.SuppressLint
+import com.jusiCool.domain.util.exception.NeedLoginException
+import java.text.SimpleDateFormat
+import java.util.Date
+
+@SuppressLint("SimpleDateFormat")
+fun String.toDate(): Date {
+    kotlin.runCatching {
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(this)!!
+    }.onSuccess {
+        return it
+    }
+    throw NeedLoginException()
+}
+
+@SuppressLint("SimpleDateFormat")
+fun Long.toJusiCoolDate(): Date {
+    return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(this).toDate()
+}

--- a/data/src/main/proto/authToken.proto
+++ b/data/src/main/proto/authToken.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "com.jusiCool.data";
+option java_multiple_files = true;
+
+message AuthToken {
+  string accessToken = 1;
+  string accessExp = 2;
+  string refreshToken = 3;
+  string refreshExp = 4;
+}

--- a/domain/src/main/java/com/jusiCool/domain/model/auth/request/PostAuthSignInRequestModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/auth/request/PostAuthSignInRequestModel.kt
@@ -1,0 +1,6 @@
+package com.jusiCool.domain.model.auth.request
+
+data class PostAuthSignInRequestModel(
+    val email: String,
+    val password: String,
+)

--- a/domain/src/main/java/com/jusiCool/domain/model/auth/request/PostAuthSignUpRequestModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/auth/request/PostAuthSignUpRequestModel.kt
@@ -1,0 +1,7 @@
+package com.jusiCool.domain.model.auth.request
+
+data class PostAuthSignUpRequestModel(
+    val email: String,
+    val name: String,
+    val password: String,
+)

--- a/domain/src/main/java/com/jusiCool/domain/model/auth/response/AuthTokenResponseModel.kt
+++ b/domain/src/main/java/com/jusiCool/domain/model/auth/response/AuthTokenResponseModel.kt
@@ -1,0 +1,8 @@
+package com.jusiCool.domain.model.auth.response
+
+data class AuthTokenResponseModel(
+    val accessToken: String,
+    val refreshToken: String,
+    val accessTokenExpiresIn: String,
+    val refreshTokenExpiresIn: String,
+)

--- a/domain/src/main/java/com/jusiCool/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/jusiCool/domain/repository/AuthRepository.kt
@@ -1,0 +1,13 @@
+package com.jusiCool.domain.repository
+
+import com.jusiCool.domain.model.auth.request.PostAuthSignInRequestModel
+import com.jusiCool.domain.model.auth.request.PostAuthSignUpRequestModel
+import com.jusiCool.domain.model.auth.response.AuthTokenResponseModel
+import kotlinx.coroutines.flow.Flow
+
+interface AuthRepository {
+    suspend fun authSignUp(body: PostAuthSignUpRequestModel) : Flow<Unit>
+    suspend fun authSignIn(body: PostAuthSignInRequestModel) : Flow<AuthTokenResponseModel>
+    suspend fun patchAuthTokenRefresh() : Flow<AuthTokenResponseModel>
+    suspend fun deleteAuth() : Flow<Unit>
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/auth/DeleteAuthUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/auth/DeleteAuthUseCase.kt
@@ -1,0 +1,12 @@
+package com.jusiCool.domain.usecase.auth
+
+import com.jusiCool.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class DeleteAuthUseCase @Inject constructor(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke() = runCatching {
+        repository.deleteAuth()
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/auth/PatchAuthTokenRefreshUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/auth/PatchAuthTokenRefreshUseCase.kt
@@ -1,0 +1,12 @@
+package com.jusiCool.domain.usecase.auth
+
+import com.jusiCool.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class PatchAuthTokenRefreshUseCase @Inject constructor(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke() = runCatching {
+        repository.patchAuthTokenRefresh()
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/auth/PostAuthSignInUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/auth/PostAuthSignInUseCase.kt
@@ -1,0 +1,13 @@
+package com.jusiCool.domain.usecase.auth
+
+import com.jusiCool.domain.model.auth.request.PostAuthSignInRequestModel
+import com.jusiCool.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class PostAuthSignInUseCase @Inject constructor(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke(body: PostAuthSignInRequestModel) = runCatching {
+        repository.authSignIn(body = body)
+    }
+}

--- a/domain/src/main/java/com/jusiCool/domain/usecase/auth/PostAuthSignUpUseCase.kt
+++ b/domain/src/main/java/com/jusiCool/domain/usecase/auth/PostAuthSignUpUseCase.kt
@@ -1,0 +1,13 @@
+package com.jusiCool.domain.usecase.auth
+
+import com.jusiCool.domain.model.auth.request.PostAuthSignUpRequestModel
+import com.jusiCool.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class PostAuthSignUpUseCase @Inject constructor(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke(body: PostAuthSignUpRequestModel) = runCatching {
+        repository.authSignUp(body = body)
+    }
+}


### PR DESCRIPTION
## 💡 개요
- auth 통신을 하기 위한 세팅을 해야합니다
## 📃 작업내용
- auth 통신을 하기 위해서 네트워크 세팅을 전반적으로 다 했습니다
## 🔀 변경사항
- feat PostAuthSign__Request(DTO - Request)
- feat AuthTokenResponse(DTO - Response)
- feat PostAuthSign__RequestModel(Model - Request)
- feat AuthTokenResponseModel(Model - Response)
- feat AuthAPI
- chore NetworkModule To AuthAPI
- feat RemoteAuthDataSource(Impl)
- chore RemoteDataSourceModule To RemoteAuthDataSource
- feat AuthRepository(Impl)
- chore RepositoryModule To AuthRepository
- feat DeleteAuthUseCase
- feat PatchAuthTokenRefreshUseCase
- feat PostAuthSignUpUseCase
- feat PostAuthSignInUseCase
- chore build.gradle(data, project) -> DataStore Elements To build.gradle(__) Files
- feat AuthTokenSerializer
- feat authToken Proto File
- feat AuthTokenDataSource(Impl)
- feat AuthTokenDataSource(Impl)
- feat DataStoreModule
- feat DateTimeFormatter
- chore AuthInterceptor
## 🙋‍♂️ 질문사항
- Nothing
## 🍴 사용방법
- Nothing
## 🎸 기타
- Nothing